### PR TITLE
Add animations as described in xtra animation demo.pdf

### DIFF
--- a/docs/Amstelvar XTRA Animation/README.md
+++ b/docs/Amstelvar XTRA Animation/README.md
@@ -1,0 +1,3 @@
+# Amstelvar XTRA Animation
+
+This page demonstrates Amstelvar's XTRA variable axis, as shown in the `xtra animation demo.pdf` document.

--- a/docs/Amstelvar XTRA Animation/amstelvar-xtra-animation.css
+++ b/docs/Amstelvar XTRA Animation/amstelvar-xtra-animation.css
@@ -1,0 +1,61 @@
+@font-face {
+	font-family: Amstelvar;
+	src: url('../../fonts/Amstelvar-Roman[wdth,wght,opsz].ttf');
+}
+
+html,
+body {
+	height: 100%;
+}
+
+body {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+}
+
+.big-box,
+.small-box {
+	font-family: Amstelvar;
+	text-align: center;
+	line-height: 1;
+	background: #dfe5ec;
+	width: calc(1em * 4);
+	margin: 1rem;
+}
+
+.big-box {
+	font-size: 140px;
+}
+
+.small-box {
+	font-size: 40px;
+}
+
+.larger {
+	animation: larger-anim 2s infinite alternate ease-in-out;
+}
+
+.widths {
+	animation: widths-anim 2s infinite alternate ease-in-out;
+}
+
+
+@keyframes larger-anim {
+	0%, 20% {
+		font-variation-settings: /*"opsz" 72,*/ "wght" 200, "wdth" 100, "XTRA" 562;
+	}
+	80%, 100% {
+		font-variation-settings: /*"opsz" 72,*/ "wght" 200, "wdth" 100, "XTRA" 570;
+	}
+}
+
+@keyframes widths-anim {
+	0%, 20% {
+		font-variation-settings: /*"opsz" 72,*/ "wght" 200, "wdth" 100, "XTRA" 562;
+	}
+	80%, 100% {
+		font-variation-settings: /*"opsz" 72,*/ "wght" 200, "wdth" 100, "XTRA" 533;
+	}
+}

--- a/docs/Amstelvar XTRA Animation/amstelvar-xtra-animation.html
+++ b/docs/Amstelvar XTRA Animation/amstelvar-xtra-animation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Amstelvar XTRA antimation</title>
+	<link rel="stylesheet" type="text/css" href="amstelvar-xtra-animation.css">
+</head>
+<body>
+
+	<div class="big-box">
+		<div class="larger">LARGER</div>
+		<div class="widths">WIDTHS</div>
+	</div>
+
+	<div class="small-box">
+		<div class="larger">LARGER</div>
+		<div class="widths">WIDTHS</div>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
Animations for finesse example, see https://github.com/GoogleChrome/web.dev/pull/3445/files#issuecomment-655781176

If these are looking good, I'll make a proper screen capture and add it to the Google article. In the big box it clearest what's going on -- only use that one?

![lw mp4](https://user-images.githubusercontent.com/4570664/89308184-44605080-d672-11ea-8866-7ec54c355b78.gif)


Note that I'm not setting the `opsz` but leaving it to the browser to use the optimal optical size based on font size. I can change this to hardcode them to 72pt regardless of shown size.